### PR TITLE
Add RemoteWrapper class and fix sharding

### DIFF
--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -413,9 +413,9 @@ def get_trainer_kwargs(
             ),
             learner_kwargs=dict(peak_lr=3e-4, weight_decay=0.1),
             max_sequence_length=max_sequence_length,
-            train_batch_size=len(jax.devices()),#int(train_batch_size/jax.process_count()), #train_batch_size,
+            train_batch_size=32,#int(train_batch_size/jax.process_count()), #train_batch_size,
             max_step=max_step,
-            mesh_shape=mesh_shape_from_axes(data=-1, fsdp=8),
+            mesh_shape=mesh_shape_from_axes(data=-1, fsdp=-1),
             mesh_rules=(
                 # Step time:
                 # v1 on tpu-v4-1024 (512 chips):            3.03s


### PR DESCRIPTION
Tested on v5e-32 cluster with global_batch_size=32

In the class RemoteInputAnnotate there are get_next() and get_next2(), corresponding to different ways to construct global array (tested in https://b.corp.google.com/issues/462744178#comment4). They both works.
